### PR TITLE
feat: add sender to deposit and withdraw events

### DIFF
--- a/contracts/PointTokenVault.sol
+++ b/contracts/PointTokenVault.sol
@@ -55,8 +55,8 @@ contract PointTokenVault is UUPSUpgradeable, AccessControlUpgradeable, Multicall
         bool isMerkleBased;
     }
 
-    event Deposit(address indexed receiver, address indexed token, uint256 amount);
-    event Withdraw(address indexed user, address indexed token, uint256 amount);
+    event Deposit(address indexed depositor, address indexed receiver, address indexed token, uint256 amount);
+    event Withdraw(address indexed withdrawer, address indexed receiver, address indexed token, uint256 amount);
     event RootUpdated(bytes32 prevRoot, bytes32 newRoot);
     event PTokensClaimed(address indexed account, bytes32 indexed pointsId, uint256 amount);
     event RewardsClaimed(address indexed owner, address indexed receiver, bytes32 indexed pointsId, uint256 amount);
@@ -95,7 +95,7 @@ contract PointTokenVault is UUPSUpgradeable, AccessControlUpgradeable, Multicall
 
         balances[_receiver][_token] += _amount;
 
-        emit Deposit(_receiver, address(_token), _amount);
+        emit Deposit(msg.sender, _receiver, address(_token), _amount);
     }
 
     function withdraw(ERC20 _token, uint256 _amount, address _receiver) public {
@@ -103,7 +103,7 @@ contract PointTokenVault is UUPSUpgradeable, AccessControlUpgradeable, Multicall
 
         _token.safeTransfer(_receiver, _amount);
 
-        emit Withdraw(_receiver, address(_token), _amount);
+        emit Withdraw(msg.sender, _receiver, address(_token), _amount);
     }
 
     /// @notice Claims point tokens after verifying the merkle proof

--- a/contracts/test/PointTokenVault.t.sol
+++ b/contracts/test/PointTokenVault.t.sol
@@ -51,6 +51,8 @@ contract PointTokenVaultTest is Test {
         pointTokenVault.setCap(address(pointEarningToken), type(uint256).max);
     }
 
+    event Deposit(address indexed depositor, address indexed receiver, address indexed token, uint256 amount);
+
     function test_Deposit() public {
         pointEarningToken.mint(vitalik, 1.123e18);
 
@@ -65,12 +67,16 @@ contract PointTokenVaultTest is Test {
 
         // Can deposit for someone else
         vm.prank(vitalik);
+        vm.expectEmit(true, true, true, true);
+        emit Deposit(vitalik, toly, address(pointEarningToken), 0.623e18);
         pointTokenVault.deposit(pointEarningToken, 0.623e18, toly);
 
         assertEq(pointEarningToken.balanceOf(vitalik), 0);
         assertEq(pointTokenVault.balances(toly, pointEarningToken), 0.623e18);
         assertEq(pointTokenVault.balances(vitalik, pointEarningToken), 0.5e18);
     }
+
+    event Withdraw(address indexed withdrawer, address indexed receiver, address indexed token, uint256 amount);
 
     function test_Withdraw() public {
         pointEarningToken.mint(vitalik, 1.123e18);
@@ -87,6 +93,8 @@ contract PointTokenVaultTest is Test {
 
         // Can withdraw with a different receiver
         vm.prank(vitalik);
+        vm.expectEmit(true, true, true, true);
+        emit Withdraw(vitalik, toly, address(pointEarningToken),  0.5e18);
         pointTokenVault.withdraw(pointEarningToken, 0.5e18, toly);
 
         assertEq(pointEarningToken.balanceOf(vitalik), 0.623e18);


### PR DESCRIPTION
include the msg.sender in the deposit and withdraw events.

rename the "user" from the withdraw event to the "receiver" to be more consistent

add event tests