### PR TITLE
feat: add prev cap

### DIFF
--- a/contracts/PointTokenVault.sol
+++ b/contracts/PointTokenVault.sol
@@ -64,7 +64,7 @@ contract PointTokenVault is UUPSUpgradeable, AccessControlUpgradeable, Multicall
         bytes32 indexed pointsId, ERC20 rewardToken, uint256 rewardsPerPToken, bool isMerkleBased
     );
     event PTokenDeployed(bytes32 indexed pointsId, address indexed pToken);
-    event CapSet(address indexed token, uint256 cap);
+    event CapSet(address indexed token, uint256 prevCap, uint256 cap);
 
     error ProofInvalidOrExpired();
     error ClaimTooLarge();
@@ -214,8 +214,9 @@ contract PointTokenVault is UUPSUpgradeable, AccessControlUpgradeable, Multicall
     }
 
     function setCap(address _token, uint256 _cap) external onlyRole(OPERATOR_ROLE) {
+        uint256 prevCap = caps[_token];
         caps[_token] = _cap;
-        emit CapSet(_token, _cap);
+        emit CapSet(_token, prevCap, _cap);
     }
 
     function setIsCapped(bool _isCapped) external onlyRole(OPERATOR_ROLE) {

--- a/contracts/test/PointTokenVault.t.sol
+++ b/contracts/test/PointTokenVault.t.sol
@@ -96,6 +96,8 @@ contract PointTokenVaultTest is Test {
         assertEq(pointTokenVault.balances(vitalik, pointEarningToken), 0);
     }
 
+    event CapSet(address indexed token, uint256 prevCap, uint256 cap);
+
     function test_DepositCaps() public {
         // Deploy a new mock token
         MockERC20 newMockToken = new MockERC20("New Test Token", "NTT", 18);
@@ -103,6 +105,8 @@ contract PointTokenVaultTest is Test {
         // Set a cap for the new token
         uint256 capAmount = 1e18; // 1 token cap
         vm.prank(operator);
+        vm.expectEmit(true, true, true, true);
+        emit CapSet(address(newMockToken), 0, capAmount);
         pointTokenVault.setCap(address(newMockToken), capAmount);
 
         // Mint tokens to vitalik


### PR DESCRIPTION
Adding the previous cap to the CapSet event.

This isn't that much of a value add, but generally seems to be the standard for updating protocol configs.