### PR TITLE
feat: only set feelessly redeemed if needed

### DIFF
--- a/contracts/PointTokenVault.sol
+++ b/contracts/PointTokenVault.sol
@@ -207,7 +207,9 @@ contract PointTokenVault is UUPSUpgradeable, AccessControlUpgradeable, Multicall
             rewardTokenFeeAcc[pointsId] += fee;
             rewardsToTransfer = amountToClaim - fee;
 
-            feelesslyRedeemedPTokens[msg.sender][pointsId] = claimed;
+            if(feelesslyRedeemed != claimed){
+                feelesslyRedeemedPTokens[msg.sender][pointsId] = claimed;
+            }
         }
 
         params.rewardToken.safeTransfer(_receiver, rewardsToTransfer);


### PR DESCRIPTION
function, contract size, average, median, max, function calls
redeemRewards    | 7186            | 75417   | 87347   | 113046  | 11      |
redeemRewards    | 7186            | 75366   | 87347   | 113046 | 11      |

Once you've used all feelesslyRedeemablePTokens, this path is taken and the value `feelesslyRedeemedPTokens[msg.sender][pointsId]` is repeatedly set equal to `claimed`, even if it already equals `claimed`.